### PR TITLE
feat(Table): add ability to set width of table column 

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -15,8 +15,7 @@ export const defaultTable = (props: any) => {
         {
           Header: 'Column 1',
           accessor: 'col1', // accessor is the "key" in the data
-          width: '50%',
-          maxWidth: 0
+          width: '50%'
         },
         {
           Header: 'Column 2',

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -15,10 +15,13 @@ export const defaultTable = (props: any) => {
         {
           Header: 'Column 1',
           accessor: 'col1', // accessor is the "key" in the data
+          width: '50%',
+          maxWidth: 0
         },
         {
           Header: 'Column 2',
           accessor: 'col2',
+          width: '50%'
         },
       ]}
       data={[

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -38,6 +38,11 @@ export function Table<D extends object = {}>({
                   // Apply the header cell props
                   <th
                     {...column.getHeaderProps()}
+                    style={{
+                      width: column.width ? column.width : 150,
+                      minWidth: column.minWidth ? column.minWidth : 0,
+                      maxWidth: column.maxWidth ? column.maxWidth : 0,
+                    }}
                     sx={{ p: 3, textAlign: 'left', fontWeight: 'normal' }}
                   >
                     {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -38,12 +38,14 @@ export function Table<D extends object = {}>({
                   // Apply the header cell props
                   <th
                     {...column.getHeaderProps()}
-                    style={{
-                      width: column.width ? column.width : 150,
-                      minWidth: column.minWidth ? column.minWidth : 0,
-                      maxWidth: column.maxWidth ? column.maxWidth : 0,
+                    sx={{ 
+                      p: 3, 
+                      textAlign: 'left', 
+                      fontWeight: 'normal',
+                      width: column.width,
+                      minWidth: column.minWidth,
+                      maxWidth: column.maxWidth,
                     }}
-                    sx={{ p: 3, textAlign: 'left', fontWeight: 'normal' }}
                   >
                     {
                       // Render the header


### PR DESCRIPTION
add ability to set width of table column by passing the argument to the Table component and set up it by width property in react-table library
Closes #45 