### PR TITLE
fix: Fix issues with dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@ Our intentions are to stylize according to _Tabetalt Designsystem_ on all [Theme
 All components are included in one package. Install it as such:
 
 ```shell
-▶ yarn install @tabetalt/kit
+▶ yarn add @tabetalt/kit
 ```
 
-**Remember to include Google Fonts** No fonts are packaged with the library. Therefore, you'll need
-to add a Link to it, as such:
+Install necessary peer dependencies.
+
+```shell
+▶ yarn add theme-ui@next
+```
+
+**Remember to include Google Fonts** No fonts are packaged with the library. Therefore, you'll need to add a Link to it, as such:
 
 ```html
 <link

--- a/package.json
+++ b/package.json
@@ -66,19 +66,14 @@
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
     "react-table": "^7.5.1",
-    "slate": "^0.59.0",
-    "slate-history": "^0.59.0",
-    "slate-react": "^0.59.0",
     "theme-ui": "^0.4.0-rc.1",
     "ts-loader": "^8.0.0",
     "typescript": "^3.9.6",
     "web-vitals": "^0.2.2"
   },
   "peerDependencies": {
-    "framer-motion": "^2.6.15",
     "react": "^16",
     "react-dom": "^16",
-    "react-table": "^7.5.1",
     "theme-ui": "next"
   },
   "release": {
@@ -112,7 +107,12 @@
   "dependencies": {
     "react-content-loader": "^5.1.1",
     "react-modal": "^3.11.2",
-    "react-tag-autocomplete": "^6.1.0"
+    "react-tag-autocomplete": "^6.1.0",
+    "framer-motion": "^2.6.15",
+    "slate": "^0.59.0",
+    "slate-history": "^0.59.0",
+    "slate-react": "^0.59.0",
+    "react-table": "^7.5.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Moving a few dependencies from `peerDependencies` to `dependencies`.

The reasoning behind this is to add stuff that you are required to install together with `@tabetalt/kit`. I have left `theme-ui` as peer dependency for now, since we utilize the `@next` tag for our developments. People are not strictly required to use the `@next` tag, and not adding `react` and `react-dom` just makes our package in-compatible with some react versions (known issue).

### Moved to `dependencies` from `devDependencies`

- slate
- slate-history
- slate-react

These packages are required for the application to work and can't be considered development dependencies.

### Moved to `peerDependencies`

- framer-motion
- react-table

This makes the user have to install `framer-motion` and `react-table` together with `@tabetalt/kit`. You can't skip that step, or else the package wouldn't work.

I also updated docs; fixed some typos and added the necessary installation step for `theme-ui`.